### PR TITLE
[Part IV] Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       value: ${{ steps.filter.outputs.challenge || steps.filter.outputs.tests }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:


### PR DESCRIPTION
Add checkout step for `python-changes` job. For PR it's not necessary, but when we want to run the job in some specifyc branch (say, `main`), the repo must be checked out.