### PR TITLE
[Part IV] CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,8 +39,7 @@ jobs:
         run: |
           TAG=$(python scripts/deploy_utils.py image_tag)
           echo $TAG
-          # echo "value=$TAG" >> $GITHUB_OUTPUT
-          echo "value=$(date +%s%N)" >> $GITHUB_OUTPUT
+          echo "value=$TAG" >> $GITHUB_OUTPUT
       - name: Check if tag is available
         id: is_tag_available
         continue-on-error: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,24 +22,18 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-      - uses: hashicorp/setup-terraform@v3
-      - name: Initialize terraform
-        run: terraform -chdir=infra init
-      - name: Store Terraform outputs
-        id: tfout
-        run: terraform -chdir=infra output -json
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GOOGLE_CREDENTIALS }}
       - name: Compute image tag
         id: image_tag
         run: |
           TAG=$(python scripts/deploy_utils.py image_tag)
           echo $TAG
           echo "value=$TAG" >> $GITHUB_OUTPUT
+      - uses: hashicorp/setup-terraform@v3
+      - name: Initialize terraform
+        run: terraform -chdir=infra init
+      - name: Store Terraform outputs
+        id: tfout
+        run: terraform -chdir=infra output -json
       - name: Check if tag is available
         id: is_tag_available
         continue-on-error: true
@@ -53,6 +47,14 @@ jobs:
           LOCATION: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}
           REPOSITORY: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_id.value }}
           PACKAGE: ${{ fromJson(steps.tfout.outputs.stdout).docker_image_name.value }}
+      - uses: docker/setup-buildx-action@v3
+        if: ${{ steps.is_tag_available.outcome == 'success' }}
+      - uses: docker/login-action@v3
+        if: ${{ steps.is_tag_available.outcome == 'success' }}
+        with:
+          registry: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
       - name: Build and push
         if: ${{ steps.is_tag_available.outcome == 'success' }}
         uses: docker/build-push-action@v5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,34 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.x
+          cache: pip
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - uses: hashicorp/setup-terraform@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Check python
+        run: python scripts/deploy_utils.py image_tag
+      - name: Initialize terraform
+        run: terraform -chdir=infra init
+      - name: Check state (sanity check)
+        run: terraform -chdir=infra state list
+      - name: Check docker
+        run: docker run hello-world

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,22 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.11.x
-          cache: pip
+        # - uses: actions/setup-python@v5
+        #   with:
+        #     python-version: 3.11.x
+        #     cache: pip
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v3
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Check python
-        run: python scripts/deploy_utils.py image_tag
+        # - uses: docker/setup-buildx-action@v3
+        #       - name: Check python
+        #         run: python scripts/deploy_utils.py image_tag
       - name: Initialize terraform
         run: terraform -chdir=infra init
       - name: Check state (sanity check)
         run: terraform -chdir=infra state list
-      - name: Check docker
-        run: docker run hello-world
+      - name: Store Terraform outputs
+        id: tfout
+        run: terraform -chdir=infra output -json
+          #      - name: Check docker
+          #        run: docker run hello-world
+      - name: Try out terraform output
+        run: |
+          echo ${{ fromJson(steps.tfout.outputs.stdout).app_uri.value }}
+          echo ${{ fromJson(steps.tfout.outputs.stdout).docker_tag_base.value }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,28 +13,56 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        # - uses: actions/setup-python@v5
-        #   with:
-        #     python-version: 3.11.x
-        #     cache: pip
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.x
+          cache: pip
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
       - uses: hashicorp/setup-terraform@v3
-        # - uses: docker/setup-buildx-action@v3
-        #       - name: Check python
-        #         run: python scripts/deploy_utils.py image_tag
       - name: Initialize terraform
         run: terraform -chdir=infra init
-      - name: Check state (sanity check)
-        run: terraform -chdir=infra state list
       - name: Store Terraform outputs
         id: tfout
         run: terraform -chdir=infra output -json
-          #      - name: Check docker
-          #        run: docker run hello-world
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - name: Check python
+        id: image_tag
+        run: |
+          TAG=$(python scripts/deploy_utils.py image_tag)
+          echo $TAG
+          # echo "value=$TAG" >> $GITHUB_OUTPUT
+          echo "value=$(date +%s%N)" >> $GITHUB_OUTPUT
+      - name: Check state (sanity check)
+        run: terraform -chdir=infra state list
+      - name: Check docker
+        run: docker run hello-world
       - name: Try out terraform output
         run: |
           echo ${{ fromJson(steps.tfout.outputs.stdout).app_uri.value }}
           echo ${{ fromJson(steps.tfout.outputs.stdout).docker_tag_base.value }}
+      - name: Checkif tag is available
+        id: is_tag_available
+        continue-on-error: true
+        run: |
+          python scripts/deploy_utils.py is_tag_available ${{ steps.image_tag.outputs.value }} \
+            --location $LOCATION \
+            --repository $REPOSITORY \
+            --package $PACKAGE
+        env:
+          LOCATION: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}
+          REPOSITORY: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_id.value }}
+          PACKAGE: ${{ fromJson(steps.tfout.outputs.stdout).docker_image_name.value }}
+      - name: Build and push
+        if: ${{ steps.is_tag_available.outcome == 'success' }}
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ fromJson(steps.tfout.outputs.stdout).docker_tag_base.value }}:${{ steps.image_tag.outputs.value }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,14 +9,15 @@ on:
       - main
 
 jobs:
-  tag:
+  build:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.image_tag.outputs.value }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11.x
-          cache: pip
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
@@ -33,30 +34,23 @@ jobs:
           registry: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GOOGLE_CREDENTIALS }}
-      - name: Check python
+      - name: Compute image tag
         id: image_tag
         run: |
           TAG=$(python scripts/deploy_utils.py image_tag)
           echo $TAG
           # echo "value=$TAG" >> $GITHUB_OUTPUT
           echo "value=$(date +%s%N)" >> $GITHUB_OUTPUT
-      - name: Check state (sanity check)
-        run: terraform -chdir=infra state list
-      - name: Check docker
-        run: docker run hello-world
-      - name: Try out terraform output
-        run: |
-          echo ${{ fromJson(steps.tfout.outputs.stdout).app_uri.value }}
-          echo ${{ fromJson(steps.tfout.outputs.stdout).docker_tag_base.value }}
-      - name: Checkif tag is available
+      - name: Check if tag is available
         id: is_tag_available
         continue-on-error: true
         run: |
-          python scripts/deploy_utils.py is_tag_available ${{ steps.image_tag.outputs.value }} \
+          python scripts/deploy_utils.py is_tag_available $TAG \
             --location $LOCATION \
             --repository $REPOSITORY \
             --package $PACKAGE
         env:
+          TAG: ${{ steps.image_tag.outputs.value }}
           LOCATION: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_location.value }}
           REPOSITORY: ${{ fromJson(steps.tfout.outputs.stdout).docker_repository_id.value }}
           PACKAGE: ${{ fromJson(steps.tfout.outputs.stdout).docker_image_name.value }}
@@ -64,5 +58,22 @@ jobs:
         if: ${{ steps.is_tag_available.outcome == 'success' }}
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           tags: ${{ fromJson(steps.tfout.outputs.stdout).docker_tag_base.value }}:${{ steps.image_tag.outputs.value }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+      - uses: hashicorp/setup-terraform@v3
+      - name: Initialize terraform
+        run: terraform -chdir=infra init
+      - name: Deploy
+        run: terraform -chdir=infra apply -auto-approve -var="docker_tag=$TAG"
+        env:
+          TAG: ${{ needs.build.outputs.image_tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__/
 # testing stuff
 /.coverage
 /reports/
+
+# GCP stuff
+latam-challenge-412300-*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY . .
 RUN ls -laR
 
 ARG PIP_ROOT_USER_ACTION=ignore
+ARG PIP_PROGRESS_BAR=off
 RUN pip install --upgrade pip
-RUN pip install -c requirements.txt --progress-bar off .
+RUN pip install -c requirements.txt .
 CMD ["uvicorn", "challenge:app", "--host", "0.0.0.0", "--port", "8080"]
 EXPOSE 8080

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -62,7 +62,8 @@ Options:
   --help            Show this message and exit.
 ```
 
-## Deployment Instructions
+## Deployment
+### Manual Instructions
 Requieres a functional `gcloud` and `docker` installation.
 
 1. Set up the infraestructure to hold the Docker images. Run `terraform
@@ -82,6 +83,21 @@ Requieres a functional `gcloud` and `docker` installation.
 The deployed URI can be checked using `terraform -chdir=infra output app_uri`.
 Ping it [here](https://latam-challenge-ubomd35csa-uc.a.run.app/) or check the
 API docs [here](https://latam-challenge-ubomd35csa-uc.a.run.app/docs/)
+
+### Continuous Deployment description
+The cotinuous deployment configuration has two jobs: `build` and `deploy`. In
+the `build` job steps 1 through 3 are run, while in the `deploy` job step 4 is
+applied.
+
+CD is configured so that if an attempt is made to rebuild an existing image in
+the artifacts repository, the build process will detect this and stop, as to
+not waste resources. In case of an skipped build process, the `deploy` job will
+be executed anyways, so that changes to the infrastructure not related to the
+image deployment are applied.
+
+If Terraform is asked to "redeploy" the current image, no expensive operation
+will be performed because the configuration will match the state exactly.
+
 
 ## Conventions
 

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -98,6 +98,12 @@ image deployment are applied.
 If Terraform is asked to "redeploy" the current image, no expensive operation
 will be performed because the configuration will match the state exactly.
 
+**Triggers**: CD is only configured to run on push to the main branch.
+Conceptually this could be described as "if tests pass, it goes to production".
+This might not be ideal in many situations, specially if integration tests are
+present, or there is a QA team that need to validate new features. For this
+application (a relatively small job challenge) i'm keeping it simple.
+
 
 ## Conventions
 


### PR DESCRIPTION
# Description
Include a Continuous Deployment workflow.

The workflow does two things:
1. Build and push the docker image to Google Artifacts Registry
2. Deploy the new image using Google Cloud Run, via Terraform.

The workflow includes some optimizations so that images are not built and uploaded twice.

# Note
Continuous deployment is only triggered by a push to main, i.e. when pull requests are merged. This is suboptimal in many cases (there is no staging preview), but for this use case I'm leaving it like this.